### PR TITLE
fix: center mobile blog-posts-carousel

### DIFF
--- a/site/fragments/articles-fragment/src/carousel/mobile-carousel/mobile-carousel.component.tsx
+++ b/site/fragments/articles-fragment/src/carousel/mobile-carousel/mobile-carousel.component.tsx
@@ -10,7 +10,7 @@ export const MobileCarousel: FC<PropsWithChildren> = ({ children }) => {
     children,
     slidesPerView: 2,
     spaceBetween: 0,
-    centered: true,
+    centered: false,
     height: 333,
     width: 700,
     loop: true,


### PR DESCRIPTION
closes https://github.com/torin-asakura/shdvor/issues/89