### PR TITLE
feat(ui): change gtag to next-component

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -11194,6 +11194,33 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@next/third-parties", [\
+      ["npm:14.2.5", {\
+        "packageLocation": "../.yarn/berry/cache/@next-third-parties-npm-14.2.5-7328944e8e-10.zip/node_modules/@next/third-parties/",\
+        "packageDependencies": [\
+          ["@next/third-parties", "npm:14.2.5"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:8eaf7ccdf5432ce8a6761a9ffc72147c3f1fe8c6d997800124c3cb0513310adcdd8036bf26d90f7ee6cf61b025615469e21455ade255e8457691b65bcefe841d#npm:14.2.5", {\
+        "packageLocation": "./.yarn/__virtual__/@next-third-parties-virtual-114de83ef3/2/.yarn/berry/cache/@next-third-parties-npm-14.2.5-7328944e8e-10.zip/node_modules/@next/third-parties/",\
+        "packageDependencies": [\
+          ["@next/third-parties", "virtual:8eaf7ccdf5432ce8a6761a9ffc72147c3f1fe8c6d997800124c3cb0513310adcdd8036bf26d90f7ee6cf61b025615469e21455ade255e8457691b65bcefe841d#npm:14.2.5"],\
+          ["@types/next", null],\
+          ["@types/react", "npm:18.3.3"],\
+          ["next", "virtual:8f6fa9a28e735490150d8793b4c44ed24272ca7b0bcf30c429ae737011bd24ed5d9c0e514bb7fc3e05eb7435dff6babbcab6918f25eadaaee50d5cd89f6fe82b#npm:14.2.5"],\
+          ["react", "npm:18.3.1"],\
+          ["third-party-capital", "npm:1.0.20"]\
+        ],\
+        "packagePeers": [\
+          "@types/next",\
+          "@types/react",\
+          "next",\
+          "react"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@nodelib/fs.scandir", [\
       ["npm:2.1.5", {\
         "packageLocation": "../.yarn/berry/cache/@nodelib-fs.scandir-npm-2.1.5-89c67370dd-10.zip/node_modules/@nodelib/fs.scandir/",\
@@ -17068,6 +17095,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@ui-gtag-virtual-8eaf7ccdf5/1/ui/gtag/",\
         "packageDependencies": [\
           ["@ui/gtag", "virtual:0142ddd73e37990b0bcb688bdfad44c69fbc10fb267f215bffc15d60906be1d7c4407677e8ee9303f1f0e30c58699a2eccd72c2dbe1bd272eb67c6a643a4eae8#workspace:ui/gtag"],\
+          ["@next/third-parties", "virtual:8eaf7ccdf5432ce8a6761a9ffc72147c3f1fe8c6d997800124c3cb0513310adcdd8036bf26d90f7ee6cf61b025615469e21455ade255e8457691b65bcefe841d#npm:14.2.5"],\
           ["@types/next", null],\
           ["@types/react", "npm:18.3.3"],\
           ["@types/react-dom", "npm:18.3.0"],\
@@ -17089,6 +17117,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./ui/gtag/",\
         "packageDependencies": [\
           ["@ui/gtag", "workspace:ui/gtag"],\
+          ["@next/third-parties", "virtual:8eaf7ccdf5432ce8a6761a9ffc72147c3f1fe8c6d997800124c3cb0513310adcdd8036bf26d90f7ee6cf61b025615469e21455ade255e8457691b65bcefe841d#npm:14.2.5"],\
           ["@types/react", "npm:18.3.3"],\
           ["@types/react-dom", "npm:18.3.0"],\
           ["next", "virtual:8f6fa9a28e735490150d8793b4c44ed24272ca7b0bcf30c429ae737011bd24ed5d9c0e514bb7fc3e05eb7435dff6babbcab6918f25eadaaee50d5cd89f6fe82b#npm:14.2.5"],\
@@ -31005,6 +31034,15 @@ const RAW_RUNTIME_STATE =
           ["@tgsnake/parser", "npm:2.1.0"],\
           ["mime-types", "npm:2.1.35"],\
           ["prompts", "npm:2.4.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["third-party-capital", [\
+      ["npm:1.0.20", {\
+        "packageLocation": "../.yarn/berry/cache/third-party-capital-npm-1.0.20-63003fae3f-10.zip/node_modules/third-party-capital/",\
+        "packageDependencies": [\
+          ["third-party-capital", "npm:1.0.20"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/ui/gtag/package.json
+++ b/ui/gtag/package.json
@@ -7,6 +7,9 @@
     ".": "./src/index.ts"
   },
   "main": "src/index.ts",
+  "dependencies": {
+    "@next/third-parties": "14.2.5"
+  },
   "devDependencies": {
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",

--- a/ui/gtag/src/gtag.component.tsx
+++ b/ui/gtag/src/gtag.component.tsx
@@ -1,31 +1,12 @@
+import type { FC }          from 'react'
+
+import type { GtagProps }   from './gtag.interfaces.js'
+
 /* eslint-disable */
-
-import type { FC }               from 'react'
-
-import type { GtagProps }        from './gtag.interfaces.js'
-
-// @ts-expect-error:next-line
-import { default as BaseScript } from 'next/script'
-import { memo }                  from 'react'
-import React                     from 'react'
-
-const Script = BaseScript as unknown as FC<any>
+import { GoogleTagManager } from '@next/third-parties/google'
+import { memo }             from 'react'
+import React                from 'react'
 
 export const Gtag: FC<GtagProps> = memo(({ gaTrackingId }) => {
-  const gtagRawString = `
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','${gaTrackingId}');
-	`
-
-  return (
-    <Script
-      id='show-banner'
-      dangerouslySetInnerHTML={{
-        __html: gtagRawString,
-      }}
-    />
-  )
+  return <GoogleTagManager gtmId={gaTrackingId} />
 })

--- a/ui/gtag/src/gtag.interfaces.ts
+++ b/ui/gtag/src/gtag.interfaces.ts
@@ -1,3 +1,3 @@
 export interface GtagProps {
-  gaTrackingId?: string
+  gaTrackingId: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5185,6 +5185,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/third-parties@npm:14.2.5":
+  version: 14.2.5
+  resolution: "@next/third-parties@npm:14.2.5"
+  dependencies:
+    third-party-capital: "npm:1.0.20"
+  peerDependencies:
+    next: ^13.0.0 || ^14.0.0
+    react: ^18.2.0
+  checksum: 10/c3ff237d9d3abb1ef5f0be278e25c60725d89b26a78d0380560e67f2943700da9feb93ea63b3974219a24018829d600953da3bc7cacb1daaa19d36079b7894f5
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -8865,6 +8877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ui/gtag@workspace:ui/gtag"
   dependencies:
+    "@next/third-parties": "npm:14.2.5"
     "@types/react": "npm:18.3.3"
     "@types/react-dom": "npm:18.3.0"
     next: "npm:14.2.5"
@@ -19551,6 +19564,13 @@ __metadata:
     mime-types: "npm:2.1.35"
     prompts: "npm:2.4.2"
   checksum: 10/ff85011b243aa4323ffe1e32d8e17e8b474ad59a0c315d6c8df38b24ea91e7f9fb3e45c36d01bd4b52b0b4b04111a838d4e5ac64c05e0cb053e9d667ea4c0c92
+  languageName: node
+  linkType: hard
+
+"third-party-capital@npm:1.0.20":
+  version: 1.0.20
+  resolution: "third-party-capital@npm:1.0.20"
+  checksum: 10/40e2531b428a21f05531fc62ef82859c0071211eff09588baf75d4b525096bbdb4f93e17e2d538849db8d4fc3cceb074933d7be59fddc26f86718fbbe852a97f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes https://github.com/torin-asakura/shdvor/issues/136

- поменял gtm-component на next-third-party-module, скрипты грузятся:
  - ![2024-12-04-135222_hyprshot](https://github.com/user-attachments/assets/a6d9560a-9fc7-4d6c-a322-fe656c345bf8)
- проверил gtm-ключи до наших правок, в текущем варианте у нас изменений нет - https://github.com/torin-asakura/shdvor/blob/62903970cfffa2413255ec46e80dd87569d2cc5d/site/app/src/pages/_document.tsx#L58