### PR TITLE
refactor(fragments/root-layout): change favicon

### DIFF
--- a/fragments/root-layout-fragment/src/hooks/generate-metadata.hook.ts
+++ b/fragments/root-layout-fragment/src/hooks/generate-metadata.hook.ts
@@ -10,10 +10,20 @@ const client = new ApolloClient({
 })
 
 export const generateMetadata = async () => {
-  const faviconResponse = await client.query({
+  const lightFaviconResponse = await client.query({
     query: gql`
       query GetFavicon {
-        mediaItemBy(uri: "/favicon/") {
+        mediaItemBy(uri: "/favicon-2/") {
+          sourceUrl
+        }
+      }
+    `,
+  })
+
+  const darkFaviconResponse = await client.query({
+    query: gql`
+      query GetFavicon {
+        mediaItemBy(uri: "/favicon_light/") {
           sourceUrl
         }
       }
@@ -23,19 +33,32 @@ export const generateMetadata = async () => {
   const appleTouchIconResponse = await client.query({
     query: gql`
       query GetFavicon {
-        mediaItemBy(uri: "/apple_touch_icon/") {
+        mediaItemBy(uri: "/apple_touch_icon-2/") {
           sourceUrl
         }
       }
     `,
   })
 
-  const iconUrl = faviconResponse.data.mediaItemBy?.sourceUrl
+  const lightIconUrl = lightFaviconResponse.data.mediaItemBy?.sourceUrl
+  const darkIconUrl = darkFaviconResponse.data.mediaItemBy?.sourceUrl
+
   const appleIconUrl = appleTouchIconResponse.data.mediaItemBy?.sourceUrl
 
   return {
     icons: {
-      icon: iconUrl,
+      icon: [
+        {
+          media: '(prefers-color-scheme: light)',
+          url: lightIconUrl,
+          href: lightIconUrl,
+        },
+        {
+          media: '(prefers-color-scheme: dark)',
+          url: darkIconUrl,
+          href: darkIconUrl,
+        },
+      ],
       apple: appleIconUrl,
     },
   }


### PR DESCRIPTION
closes https://github.com/torin-asakura/shdvor/issues/141

- загрузил фавиконки на WP
- разделил темную и светлую версию. раньше была одна

![image](https://github.com/user-attachments/assets/44275073-139b-4b8e-b15c-95c0ed49780c)
![image](https://github.com/user-attachments/assets/deb86eee-a1fb-4ed7-b90f-0158d7f2da86)
### apple-touch-icon проверял через сервис - https://realfavicongenerator.net/
![image](https://github.com/user-attachments/assets/7295f01d-c0db-43bf-93e4-0f250887b062)


