### PR TITLE
feat(ui): adapt to new library

### DIFF
--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -8,23 +8,21 @@
   },
   "main": "src/index.ts",
   "dependencies": {
-    "@atls-ui-parts/layout": "0.1.1"
+    "@atls-ui-parts/layout": "1.0.2",
+    "@ui/theme": "workspace:*"
   },
   "devDependencies": {
-    "@emotion/react": "11.13.0",
-    "@emotion/styled": "11.13.0",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "@types/styled-system": "5.1.22",
+    "@vanilla-extract/css": "1.16.1",
+    "rainbow-sprinkles": "0.17.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "styled-system": "5.1.5"
+    "react-dom": "18.3.1"
   },
   "peerDependencies": {
-    "@emotion/react": "*",
-    "@emotion/styled": "*",
+    "@vanilla-extract/css": "*",
+    "rainbow-sprinkles": "*",
     "react": "*",
-    "react-dom": "*",
-    "styled-system": "*"
+    "react-dom": "*"
   }
 }

--- a/ui/layout/src/box/box.component.tsx
+++ b/ui/layout/src/box/box.component.tsx
@@ -1,0 +1,20 @@
+import type { FC }                       from 'react'
+import type { PropsWithChildren }        from 'react'
+
+import type { ResponsiveContainerProps } from '../responsive-container/index.js'
+
+import { Box as BaseBox }                from '@atls-ui-parts/layout'
+import React                             from 'react'
+
+import { PropsMapper }                   from '../mappers/props.mapper.js'
+import { rainbowSprinkles }              from '../responsive-container/index.js'
+
+export const Box: FC<PropsWithChildren<ResponsiveContainerProps>> = ({ children, ...props }) => {
+  const mappedProps = PropsMapper.sprinklesProps(props)
+  const { className, style, otherProps } = rainbowSprinkles(mappedProps)
+  return (
+    <BaseBox className={className} style={style} {...otherProps}>
+      {children}
+    </BaseBox>
+  )
+}

--- a/ui/layout/src/box/index.ts
+++ b/ui/layout/src/box/index.ts
@@ -1,0 +1,1 @@
+export * from './box.component.js'

--- a/ui/layout/src/column/column.component.tsx
+++ b/ui/layout/src/column/column.component.tsx
@@ -1,0 +1,20 @@
+import type { FC }                       from 'react'
+import type { PropsWithChildren }        from 'react'
+
+import type { ResponsiveContainerProps } from '../responsive-container/index.js'
+
+import { Column as BaseColumn }          from '@atls-ui-parts/layout'
+import React                             from 'react'
+
+import { PropsMapper }                   from '../mappers/props.mapper.js'
+import { rainbowSprinkles }              from '../responsive-container/index.js'
+
+export const Column: FC<PropsWithChildren<ResponsiveContainerProps>> = ({ children, ...props }) => {
+  const mappedProps = PropsMapper.sprinklesProps(props)
+  const { className, style, otherProps } = rainbowSprinkles(mappedProps)
+  return (
+    <BaseColumn className={className} style={style} {...otherProps}>
+      {children}
+    </BaseColumn>
+  )
+}

--- a/ui/layout/src/column/index.ts
+++ b/ui/layout/src/column/index.ts
@@ -1,0 +1,1 @@
+export * from './column.component.js'

--- a/ui/layout/src/index.ts
+++ b/ui/layout/src/index.ts
@@ -1,1 +1,4 @@
-export * from '@atls-ui-parts/layout'
+export * from './box/index.js'
+export * from './layout/index.js'
+export * from './row/index.js'
+export * from './column/index.js'

--- a/ui/layout/src/layout/index.ts
+++ b/ui/layout/src/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './layout.component.js'

--- a/ui/layout/src/layout/layout.component.tsx
+++ b/ui/layout/src/layout/layout.component.tsx
@@ -1,0 +1,20 @@
+import type { FC }                       from 'react'
+import type { PropsWithChildren }        from 'react'
+
+import type { ResponsiveContainerProps } from '../responsive-container/index.js'
+
+import { Layout as BaseLayout }          from '@atls-ui-parts/layout'
+import React                             from 'react'
+
+import { PropsMapper }                   from '../mappers/props.mapper.js'
+import { rainbowSprinkles }              from '../responsive-container/index.js'
+
+export const Layout: FC<PropsWithChildren<ResponsiveContainerProps>> = ({ children, ...props }) => {
+  const mappedProps = PropsMapper.sprinklesProps(props)
+  const { className, style, otherProps } = rainbowSprinkles(mappedProps)
+  return (
+    <BaseLayout className={className} style={style} {...otherProps}>
+      {children}
+    </BaseLayout>
+  )
+}

--- a/ui/layout/src/mappers/index.ts
+++ b/ui/layout/src/mappers/index.ts
@@ -1,0 +1,1 @@
+export * from './props.mapper.js'

--- a/ui/layout/src/mappers/props.constants.ts
+++ b/ui/layout/src/mappers/props.constants.ts
@@ -1,0 +1,1 @@
+export const WITHOUT_PIXELS_PROPERTY_NAMES = ['zIndex']

--- a/ui/layout/src/mappers/props.mapper.ts
+++ b/ui/layout/src/mappers/props.mapper.ts
@@ -1,0 +1,93 @@
+import type { BreakpointKey }            from '@ui/theme'
+
+import type { ResponsiveContainerProps } from '../responsive-container/index.js'
+import type { Sprinkles }                from '../responsive-container/index.js'
+import type { SprinklesArray }           from '../responsive-container/index.js'
+
+import { BREAKPOINT_CONDITIONS }         from '@ui/theme'
+
+import { WITHOUT_PIXELS_PROPERTY_NAMES } from './props.constants.js'
+
+type PropKey = keyof ResponsiveContainerProps
+// type MappedArrayType = { [K in BreakpointKey]?: number | string | undefined }
+type MappedArrayType = Partial<Record<BreakpointKey, number | string | undefined>>
+
+enum PropVaueTypes {
+  Common = 'common',
+  Array = 'array',
+  Pixels = 'pixels',
+}
+
+export class PropsMapper {
+  static sprinklesProps(props: ResponsiveContainerProps): Sprinkles {
+    const mappedProps: Sprinkles = {}
+
+    Object.entries(props).forEach(([unknownPropKey, propValue]) => {
+      if (!propValue) return
+
+      const propKey = unknownPropKey as unknown as PropKey
+      const propValueType = this.getPropValueType(propKey, propValue)
+
+      switch (propValueType) {
+        case PropVaueTypes.Array:
+          // @ts-expect-error complex union type
+          mappedProps[propKey] = this.mapArrayPropValue(propKey, propValue as SprinklesArray)
+          break
+        case PropVaueTypes.Pixels:
+          mappedProps[propKey] = `${propValue as number}px`
+          break
+        default:
+          mappedProps[propKey] = propValue
+      }
+    })
+
+    return mappedProps
+  }
+
+  private static mapArrayPropValue = (
+    propKey: PropKey,
+    propValue: Array<number | string | null | undefined>
+  ): MappedArrayType => {
+    const mappedPropValue: MappedArrayType = {}
+
+    Object.keys(BREAKPOINT_CONDITIONS).forEach((value, index) => {
+      const conditionName = value as unknown as BreakpointKey
+      const indexPropValue = propValue[index]
+      const propValueType = this.getPropValueType(propKey, indexPropValue)
+
+      if (indexPropValue) {
+        switch (propValueType) {
+          case PropVaueTypes.Pixels:
+            mappedPropValue[conditionName] = `${indexPropValue}px`
+            break
+          default:
+            mappedPropValue[conditionName] = indexPropValue
+        }
+      }
+    })
+
+    return mappedPropValue
+  }
+
+  private static getPropValueType(propKey: PropKey, propValue: unknown): PropVaueTypes {
+    if (Array.isArray(propValue)) {
+      return PropVaueTypes.Array
+    }
+
+    if (this.checkPixelsPropValueCondition(propKey, propValue)) {
+      return PropVaueTypes.Pixels
+    }
+
+    return PropVaueTypes.Common
+  }
+
+  private static checkPixelsPropValueCondition(propKey: PropKey, propValue: unknown): boolean {
+    if (
+      typeof propValue === 'number' &&
+      propValue !== 0 &&
+      !WITHOUT_PIXELS_PROPERTY_NAMES.includes(propKey)
+    )
+      return true
+    return false
+  }
+}

--- a/ui/layout/src/responsive-container/index.ts
+++ b/ui/layout/src/responsive-container/index.ts
@@ -1,0 +1,2 @@
+export * from './responsive-container.css.js'
+export * from './responsive-container.interface.js'

--- a/ui/layout/src/responsive-container/responsive-container.css.ts
+++ b/ui/layout/src/responsive-container/responsive-container.css.ts
@@ -1,0 +1,48 @@
+import { createRainbowSprinkles } from 'rainbow-sprinkles'
+import { defineProperties }       from 'rainbow-sprinkles'
+
+import { BREAKPOINT_CONDITIONS }  from '@ui/theme'
+import { vars }                   from '@ui/theme'
+
+const responsiveContainerProperties = defineProperties({
+  conditions: BREAKPOINT_CONDITIONS,
+  defaultCondition: 'mobile',
+  dynamicProperties: {
+    width: true,
+    height: true,
+    maxHeight: true,
+    minWidth: true,
+    minHeight: true,
+    maxWidth: true,
+
+    zIndex: true,
+    display: true,
+    overflow: true,
+    position: true,
+
+    marginTop: true,
+    padding: true,
+    paddingTop: true,
+    paddingBottom: true,
+    top: true,
+    right: true,
+
+    gap: true,
+    flexWrap: true,
+    justifyContent: true,
+    alignItems: true,
+
+    flexGrow: true,
+    flexDirection: true,
+    flexBasis: true,
+    flexShrink: true,
+  },
+  staticProperties: {
+    backgroundColor: vars.colors,
+    borderRadius: vars.radii,
+    border: vars.borders,
+  },
+})
+
+export const rainbowSprinkles = createRainbowSprinkles(responsiveContainerProperties)
+export type Sprinkles = Parameters<typeof rainbowSprinkles>[0]

--- a/ui/layout/src/responsive-container/responsive-container.interface.ts
+++ b/ui/layout/src/responsive-container/responsive-container.interface.ts
@@ -1,0 +1,25 @@
+import type { BreakpointKey } from '@ui/theme'
+
+import { Sprinkles }          from './responsive-container.css.js'
+
+type SprinklesResponseObject = Partial<Record<BreakpointKey, any>>
+
+type SprinklesKey = keyof Sprinkles
+type SprinklesElement<T extends SprinklesKey> = Sprinkles[T]
+
+type SprinklesArrayElement<T extends SprinklesKey> = Exclude<
+  SprinklesElement<T>,
+  SprinklesResponseObject
+>
+export type SprinklesArray<T extends SprinklesKey> = Array<SprinklesArrayElement<T>>
+
+type SprinklesPropWithArray<T extends SprinklesKey> = SprinklesArray<T> | SprinklesElement<T>
+
+export type ResponsiveContainerProps = Sprinkles & {
+  [K in SprinklesKey]?: SprinklesPropWithArray<K>
+} & {
+  style?: React.CSSProperties
+  fill?: boolean
+  ref?: React.MutableRefObject<HTMLDivElement | null>
+  className?: string
+}

--- a/ui/layout/src/row/index.ts
+++ b/ui/layout/src/row/index.ts
@@ -1,0 +1,1 @@
+export * from './row.component.js'

--- a/ui/layout/src/row/row.component.tsx
+++ b/ui/layout/src/row/row.component.tsx
@@ -1,0 +1,20 @@
+import type { FC }                       from 'react'
+import type { PropsWithChildren }        from 'react'
+
+import type { ResponsiveContainerProps } from '../responsive-container/index.js'
+
+import { Row as BaseRow }                from '@atls-ui-parts/layout'
+import React                             from 'react'
+
+import { PropsMapper }                   from '../mappers/props.mapper.js'
+import { rainbowSprinkles }              from '../responsive-container/index.js'
+
+export const Row: FC<PropsWithChildren<ResponsiveContainerProps>> = ({ children, ...props }) => {
+  const mappedProps = PropsMapper.sprinklesProps(props)
+  const { className, style, otherProps } = rainbowSprinkles(mappedProps)
+  return (
+    <BaseRow className={className} style={style} {...otherProps}>
+      {children}
+    </BaseRow>
+  )
+}


### PR DESCRIPTION
### в этом ПР:

- адаптирую layout для работы с новой библиотекой
- новая либа не принимает массивы для работы responsive, поэтому написал промежуточный mapper

---

@Nelfimov Никит, я правильно понял метод слияния веток?

если сливать все кусками, то работать это будет только после того, как я залью `pages & fragments`, а они еще в процессе ( в `root-fragment` подключаю новую тему )

- закину еще пару компонентов в параллельных ПР
- жду `appearance` для `button`. сейчас на правках в макете, чтобы запустить генератор
- после этого обновлю `theme`
- после этого перепроверю/дополню `fragments & pages` с обновленными `button-variants`

получатся еще такие ПР:
- [ ] - `ui/text` - готов, залю следом
- [ ] - `ui/theme `- жду обновлений в макете, нужно будет перегенерировать
- [ ] - `ui/button` - жду обновлений в макете. `shapes` готовы, нужно перегенерировать `appearance`, жду
- [ ] - `fragments(shared)` - жду обновлений в макете, чтобы перепроверить наименования `button-variants`.
- [ ] - `site/fragments` - аналогично ^
- [ ] - `site/pages` - аналогично ^
- [ ] - `blog/fragments` - аналогично ^
- [ ] - `blog/pages` - аналогично ^